### PR TITLE
SECOPS-353 Adding codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*           @B-Communications/cap_mobile


### PR DESCRIPTION
@bogdanFZ  with this change combined with branch protection will require that someone from cap_mobile approve all PRs into this repo, please consider if this will negatively affect the team